### PR TITLE
Check for CMD_DURATION before calling __format_time

### DIFF
--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -133,7 +133,9 @@ function fish_prompt
   end
 
   # Prompt command execution duration
-  set command_duration (__format_time $CMD_DURATION $pure_command_max_exec_time)
+  if test -n "$CMD_DURATION"
+    set command_duration (__format_time $CMD_DURATION $pure_command_max_exec_time)
+  end
   set prompt $prompt "$pure_color_yellow$command_duration$pure_color_normal"
 
   set prompt $prompt "\n$color_symbol$pure_symbol_prompt$pure_color_normal "


### PR DESCRIPTION
The `CMD_DURATION` variable has no value when first opening a shell session, therefore we check if it's been initialized before passing it to `__format_time`.

**EDIT:** Checked the [fish codebase](https://github.com/fish-shell/fish-shell/blob/8efe88201eefa767b8554f4a4db556f86c80558a/src/reader.cpp#L751) and the variable **is** supposed to hold a value on first start, so I'm unsure why this is failling.

Without this check, I get the following error:

```
Array index out of bounds
~/.config/fish/functions/__format_time.fish (line 7):   set -l threshold $argv[2]
                                                                               ^
in function “__format_time”
        called on line 41 of file ~/.config/fish/functions/fish_prompt.fish
        with parameter list “5”

in command substitution
        called on line 39 of file ~/.config/fish/functions/fish_prompt.fish

in function “fish_prompt”
        called on standard input

in command substitution
        called on standard input

test: Missing argument at index 2
```